### PR TITLE
Support for testing and configuration XML merging

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,19 @@
+name: Python CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7']
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+      - name: Install depenedncies
+        run: |
+          python -m pip install --upgrade pip
+          pip install networkx pandas jinja2
+      - name: Run unittests
+        run: python -m unittest
+      - name: Run doctest
+        run: python -m doctest -v merge_baseline_configuration_xmls.py

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,26 @@
+name: Deploy to PYPI
+on:
+  push:
+    branches:
+      - develop
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.7'
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip setuptools
+          python3 -m pip install --upgrade twine wheel
+      - name: Create and check packages
+        run: |
+          python -m build --sdist --wheel --outdir dist/ .
+      - name: Publish to PyPI
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@v1.0.0a0
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ optional arguments:
   -d DIRECTORY_WITH_SDRFS, --directory-with-sdrfs DIRECTORY_WITH_SDRFS
                         Directory with SDRFs to merge
   -o OUTPUT, --output OUTPUT
-                        Path for output sdrf.
+                        File path for output SDRF (not a directory path)..
   --accessions-file ACCESSIONS_FILE
                         File with comma separated list of accessions to use only. Overrides accessions list.
   -a ACCESSIONS_LIST, --accessions-list ACCESSIONS_LIST

--- a/README.md
+++ b/README.md
@@ -91,4 +91,33 @@ then the `--covariate-skip-values` allows to skip such values from the graph cre
 If you need an SDRF with the equivalent merged content, then use the first script listed here limited to the accessions
 that where selected by this process.
 
+## Merge assay groups XMLs for baseline experiments
+
+In Expression Atlas MAGE-Tab files are often accompanied by XML files that encode
+relations between assay groups. For baseline studies, these are generated from the SDRF. For loading merged studies,
+a merged XML config file is needed (as with any baseline experiment).
+
+Given a set of configuration XML files, named as <ACCESSION>-configuration.xml and a set of accessions,
+the following can be run to merge them into a single XML:
+
+```
+usage: merge_baseline_configuration_xmls.py [-h] -x DIRECTORY_WITH_CONFIGURATION_FILES
+                                            [--accessions-file ACCESSIONS_FILE] [-a ACCESSIONS_LIST] -o
+                                            OUTPUT -n NEW_ACCESSION
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -x DIRECTORY_WITH_CONFIGURATION_FILES, --directory-with-configuration-files DIRECTORY_WITH_CONFIGURATION_FILES
+                        Directory with configuration XMLs to merge
+  --accessions-file ACCESSIONS_FILE
+                        File with comma separated list of accessions to use only. Overrides accessions
+                        list.
+  -a ACCESSIONS_LIST, --accessions-list ACCESSIONS_LIST
+                        Comma-separated list of accessions to use only.
+  -o OUTPUT, --output OUTPUT
+                        Path for output. <new-accession>-configuration.xml will be created there.
+  -n NEW_ACCESSION, --new-accession NEW_ACCESSION
+                        New accession for the output
+```
+
 

--- a/SDRF/__init__.py
+++ b/SDRF/__init__.py
@@ -209,6 +209,9 @@ class SDRFColumn(object):
         :return: true if merged
         """
         if outer == self:
+            # Note that the equals method for SDRFColumn is overridden
+            # to depend only on the name and type of the column, not that
+            # it is the same object in memory.
             original_size = self.column_data.size
             self.column_data = self.column_data.append(outer.column_data, ignore_index=True)
 

--- a/SDRF/__init__.py
+++ b/SDRF/__init__.py
@@ -562,7 +562,13 @@ class SDRF(object):
                     node_obj = n
 
         if not node_obj:
-            print(f"WARNING {node} node or node subfield specified not found... skipping prepending {value}")
+            if comment_name:
+                print(
+                    f"WARNING {node} node or node comment {comment_name} specified not found... "
+                    f"skipping prepending value {value} to that node.")
+            else:
+                print(
+                    f"WARNING {node} node specified not found... skipping prepending value {value} to than node.")
             return
 
         if change_empty:

--- a/merge_baseline_configuration_xmls.py
+++ b/merge_baseline_configuration_xmls.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+
+import xml.etree.ElementTree as ET
+import argparse
+import os.path
+
+arg_parser = argparse.ArgumentParser()
+
+arg_parser.add_argument('-x', '--directory-with-configuration-files',
+                        required=True,
+                        help="Directory with configuration XMLs to merge"
+                        )
+arg_parser.add_argument('--accessions-file', required=False,
+                        help="File with comma separated list of accessions to use only. "
+                             "Overrides accessions list."
+                        )
+arg_parser.add_argument('-a', '--accessions-list', required=False,
+                        help="Comma-separated list of accessions to use only."
+                        )
+arg_parser.add_argument('-o', '--output', required=True,
+                        help="Path for output. <new-accession>-configuration.xml"
+                             "will be created there."
+                        )
+arg_parser.add_argument('-n', '--new-accession', help='New accession for the output',
+                        required=True)
+
+
+def _get_test_path():
+    """Returns test data path"""
+    path, name = os.path.split(__file__)
+    return os.path.join(path, 'test-data')
+
+def _get_test_fname(fname):
+    """Returns test data filename"""
+    path = _get_test_path()
+    full_path = os.path.join(path, fname)
+    return full_path
+
+def baseline_xml_configuration_skeleton():
+    """
+    Produces an empty XML object where additional assay groups can be added.
+    For convenience, it returns the root element conf (to be dumped later into a file)
+    and the assay_groups element, where additional assay groups should be added
+
+    :return:
+    """
+    conf = ET.Element("configuration")
+    # TODO these should be parameters
+    conf.set("experimentType","rnaseq_mrna_baseline")
+    conf.set("r_data","1")
+    analytics = ET.SubElement(conf, "analytics")
+    assay_groups = ET.SubElement(analytics, "assay_groups")
+
+    return conf, assay_groups
+
+def get_assay_groups(path):
+    """
+    Get a list of assay group elements from the specified configuration.xml file.
+
+    :param path: to the configuration XML file.
+    :return: list of all "assay_group" XML ET Elements.
+    >>> assay_groups = get_assay_groups(_get_test_fname("E-MTAB-513-configuration.xml"))
+    >>> len(list(assay_groups)) == 16
+    True
+    """
+    root_ext = ET.parse(path).getroot()
+    return root_ext.iter("assay_group")
+
+
+def get_specified_accessions(args):
+    accessions = None
+    if args.accessions_file:
+        with open(args.accessions_file, mode='r') as acc:
+            accessions = acc.read().split(sep=",")
+    elif args.accessions_list:
+        accessions = args.accessions_list.split(sep=",")
+    return accessions
+
+def prepend_accession_technical_replicate(assay: ET.Element, accession):
+    field = "technical_replicate_id"
+    tech_rep_id = assay.get(field)
+    if tech_rep_id:
+        assay.set(field, f"{accession}_{tech_rep_id}")
+
+
+def add_assay_groups_from_accession(path, accession, assay_groups: ET.Element, count_offset=0):
+    """
+    Given an accession and the path to the directory where the config XML resides,
+    it traverses all its assay_group elements and adds as children to the assay_groups ET.Element.
+
+    :param path: to the directory where the <ACCESSION>-configuration.xml file resides
+    :param accession: the <ACCESSION> of the study
+    :param assay_groups: ET.Element where all the assay_groups available in the XML will be stored.
+    :return:
+    >>> ag = ET.Element("assay_groups")
+    >>> accession = "E-MTAB-2836"
+    >>> path = _get_test_path()
+    >>> add_assay_groups_from_accession(path, accession, ag)
+    32
+    >>> children = ag.getchildren()
+    >>> len(children)
+    32
+    >>> children[28].get("label") == f"tonsil; {accession}"
+    True
+    """
+    conf_xml_path = f"{path}/{accession}-configuration.xml"
+    ag_counter = 0
+    if os.path.isfile(conf_xml_path):
+        for ag in get_assay_groups(conf_xml_path):
+            ag.set("label", f"{ag.get('label')}; {accession}")
+            ag.set("id", f"g{ag_counter+count_offset}")
+            [prepend_accession_technical_replicate(assay, accession) for assay in ag]
+            assay_groups.append(ag)
+            ag_counter += 1
+    else:
+        print(f"Configuration file not found: {conf_xml_path}")
+    return ag_counter
+
+
+if __name__ == '__main__':
+    args = arg_parser.parse_args()
+
+    if not args.accessions_file and not args.accessions_list:
+        print("Either --accessions or --accessions-file needs to be specified")
+
+    root, assay_groups = baseline_xml_configuration_skeleton()
+
+    assay_group_counter = 0
+    for accession in get_specified_accessions(args):
+        assay_group_counter += add_assay_groups_from_accession(path=args.directory_with_configuration_files,
+                                                               accession=accession,
+                                                               assay_groups=assay_groups,
+                                                               count_offset=assay_group_counter
+                                                               )
+
+    tree = ET.ElementTree(root)
+    tree.write(f"{args.output}/{args.new_accession}-configuration.xml", encoding="UTF-8", xml_declaration=True)
+
+

--- a/merge_baseline_configuration_xmls.py
+++ b/merge_baseline_configuration_xmls.py
@@ -97,7 +97,7 @@ def add_assay_groups_from_accession(path, accession, assay_groups: ET.Element, c
     >>> path = _get_test_path()
     >>> add_assay_groups_from_accession(path, accession, ag)
     32
-    >>> children = ag.getchildren()
+    >>> children = [x for x in ag]
     >>> len(children)
     32
     >>> children[28].get("label") == f"tonsil; {accession}"

--- a/merge_sdrfs.py
+++ b/merge_sdrfs.py
@@ -13,7 +13,7 @@ arg_parser.add_argument('-d', '--directory-with-sdrfs',
                         help="Directory with SDRFs to merge"
                         )
 arg_parser.add_argument('-o', '--output', required=True,
-                        help="Path for output sdrf."
+                        help="File path for output SDRF (not a directory path)."
                         )
 arg_parser.add_argument('--accessions-file', required=False,
                         help="File with comma separated list of accessions to use only. "

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ print(find_packages())
 
 setup(
         name='MAGE-Tab merger',
-        version='0.0.1',
+        version='0.0.2',
         description='Merges MAGE-Tab files considering covariates',
         long_description=readme(),
         packages=find_packages(),
@@ -18,6 +18,6 @@ setup(
         author='Pablo Moreno',
         long_description_content_type='text/markdown',
         author_email='',
-        scripts=['merge_condensed_sdrfs.py', 'merge_sdrfs.py'],
+        scripts=['merge_condensed_sdrfs.py', 'merge_sdrfs.py', 'merge_baseline_configuration_xmls.py'],
         license='MIT'
     )

--- a/test-data/E-MTAB-2836-configuration.xml
+++ b/test-data/E-MTAB-2836-configuration.xml
@@ -1,0 +1,272 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration experimentType="rnaseq_mrna_baseline" r_data="1">
+    <analytics>
+        <assay_groups>
+            <assay_group id="g1" label="adipose tissue">
+                <assay>ERR579122</assay>
+                <assay>ERR315332</assay>
+                <assay>ERR579146</assay>
+                <assay technical_replicate_id="t1">ERR315342</assay>
+                <assay technical_replicate_id="t1">ERR315343</assay>
+                <assay technical_replicate_id="t5">ERR315431</assay>
+                <assay technical_replicate_id="t5">ERR315378</assay>
+            </assay_group>
+            <assay_group id="g2" label="adrenal gland">
+                <assay technical_replicate_id="t11">ERR315452</assay>
+                <assay technical_replicate_id="t11">ERR315335</assay>
+                <assay technical_replicate_id="t35">ERR315450</assay>
+                <assay technical_replicate_id="t35">ERR315392</assay>
+                <assay technical_replicate_id="t60">ERR315385</assay>
+                <assay technical_replicate_id="t60">ERR315417</assay>
+            </assay_group>
+            <assay_group id="g3" label="bone marrow">
+                <assay technical_replicate_id="t12">ERR315469</assay>
+                <assay technical_replicate_id="t12">ERR315425</assay>
+                <assay technical_replicate_id="t17">ERR315333</assay>
+                <assay technical_replicate_id="t17">ERR315395</assay>
+                <assay technical_replicate_id="t45">ERR315406</assay>
+                <assay technical_replicate_id="t45">ERR315404</assay>
+                <assay technical_replicate_id="t48">ERR315486</assay>
+                <assay technical_replicate_id="t48">ERR315396</assay>
+            </assay_group>
+            <assay_group id="g4" label="cerebral cortex">
+                <assay>ERR315477</assay>
+                <assay>ERR315432</assay>
+                <assay>ERR315455</assay>
+            </assay_group>
+            <assay_group id="g5" label="colon">
+                <assay>ERR315400</assay>
+                <assay>ERR315462</assay>
+                <assay>ERR579148</assay>
+                <assay>ERR315348</assay>
+                <assay>ERR315484</assay>
+                <assay>ERR579129</assay>
+                <assay technical_replicate_id="t67">ERR315357</assay>
+                <assay technical_replicate_id="t67">ERR315403</assay>
+            </assay_group>
+            <assay_group id="g6" label="duodenum">
+                <assay technical_replicate_id="t40">ERR315442</assay>
+                <assay technical_replicate_id="t40">ERR315457</assay>
+                <assay technical_replicate_id="t64">ERR315461</assay>
+                <assay technical_replicate_id="t64">ERR315445</assay>
+            </assay_group>
+            <assay_group id="g7" label="endometrium">
+                <assay>ERR579123</assay>
+                <assay>ERR579138</assay>
+                <assay technical_replicate_id="t23">ERR315495</assay>
+                <assay technical_replicate_id="t23">ERR315361</assay>
+                <assay technical_replicate_id="t23">ERR315490</assay>
+                <assay technical_replicate_id="t4">ERR315368</assay>
+                <assay technical_replicate_id="t4">ERR315433</assay>
+                <assay technical_replicate_id="t53">ERR315386</assay>
+                <assay technical_replicate_id="t53">ERR315438</assay>
+            </assay_group>
+            <assay_group id="g8" label="esophagus">
+                <assay technical_replicate_id="t27">ERR315411</assay>
+                <assay technical_replicate_id="t27">ERR315362</assay>
+                <assay technical_replicate_id="t3">ERR315398</assay>
+                <assay technical_replicate_id="t3">ERR315472</assay>
+                <assay technical_replicate_id="t6">ERR315489</assay>
+                <assay technical_replicate_id="t6">ERR315434</assay>
+            </assay_group>
+            <assay_group id="g9" label="fallopian tube">
+                <assay>ERR579155</assay>
+                <assay>ERR579128</assay>
+                <assay>ERR579136</assay>
+                <assay>ERR579150</assay>
+                <assay>ERR579134</assay>
+                <assay>ERR579124</assay>
+            </assay_group>
+            <assay_group id="g10" label="gall bladder">
+                <assay technical_replicate_id="t10">ERR315427</assay>
+                <assay technical_replicate_id="t10">ERR315360</assay>
+                <assay technical_replicate_id="t15">ERR315470</assay>
+                <assay technical_replicate_id="t15">ERR315474</assay>
+                <assay technical_replicate_id="t15">ERR315349</assay>
+                <assay technical_replicate_id="t38">ERR315480</assay>
+                <assay technical_replicate_id="t38">ERR315347</assay>
+            </assay_group>
+            <assay_group id="g11" label="heart">
+                <assay technical_replicate_id="t30">ERR315331</assay>
+                <assay technical_replicate_id="t30">ERR315367</assay>
+                <assay technical_replicate_id="t31">ERR315389</assay>
+                <assay technical_replicate_id="t31">ERR315328</assay>
+                <assay technical_replicate_id="t31">ERR315435</assay>
+                <assay technical_replicate_id="t32">ERR315356</assay>
+                <assay technical_replicate_id="t32">ERR315430</assay>
+                <assay technical_replicate_id="t37">ERR315384</assay>
+                <assay technical_replicate_id="t37">ERR315413</assay>
+            </assay_group>
+            <assay_group id="g12" label="kidney">
+                <assay>ERR315443</assay>
+                <assay>ERR315494</assay>
+                <assay>ERR315383</assay>
+                <assay>ERR315468</assay>
+            </assay_group>
+            <assay_group id="g13" label="liver">
+                <assay>ERR315414</assay>
+                <assay technical_replicate_id="t33">ERR315327</assay>
+                <assay technical_replicate_id="t33">ERR315394</assay>
+                <assay technical_replicate_id="t39">ERR315463</assay>
+                <assay technical_replicate_id="t39">ERR315451</assay>
+            </assay_group>
+            <assay_group id="g14" label="lung">
+                <assay>ERR315341</assay>
+                <assay>ERR315346</assay>
+                <assay technical_replicate_id="t13">ERR315353</assay>
+                <assay technical_replicate_id="t13">ERR315487</assay>
+                <assay technical_replicate_id="t54">ERR315326</assay>
+                <assay technical_replicate_id="t54">ERR315424</assay>
+                <assay technical_replicate_id="t66">ERR315439</assay>
+                <assay technical_replicate_id="t66">ERR315444</assay>
+            </assay_group>
+            <assay_group id="g15" label="lymph node">
+                <assay technical_replicate_id="t18">ERR315488</assay>
+                <assay technical_replicate_id="t18">ERR315393</assay>
+                <assay technical_replicate_id="t20">ERR315371</assay>
+                <assay technical_replicate_id="t20">ERR315373</assay>
+                <assay technical_replicate_id="t46">ERR315493</assay>
+                <assay technical_replicate_id="t46">ERR315441</assay>
+                <assay technical_replicate_id="t46">ERR315440</assay>
+                <assay technical_replicate_id="t52">ERR315329</assay>
+                <assay technical_replicate_id="t52">ERR315390</assay>
+                <assay technical_replicate_id="t52">ERR315471</assay>
+                <assay technical_replicate_id="t7">ERR315475</assay>
+                <assay technical_replicate_id="t7">ERR315426</assay>
+                <assay technical_replicate_id="t7">ERR315387</assay>
+            </assay_group>
+            <assay_group id="g16" label="ovary">
+                <assay>ERR579132</assay>
+                <assay technical_replicate_id="t2">ERR315458</assay>
+                <assay technical_replicate_id="t2">ERR315402</assay>
+                <assay technical_replicate_id="t56">ERR315482</assay>
+                <assay technical_replicate_id="t56">ERR315380</assay>
+            </assay_group>
+            <assay_group id="g17" label="pancreas">
+                <assay technical_replicate_id="t41">ERR315479</assay>
+                <assay technical_replicate_id="t41">ERR315466</assay>
+                <assay technical_replicate_id="t61">ERR315436</assay>
+                <assay technical_replicate_id="t61">ERR315429</assay>
+            </assay_group>
+            <assay_group id="g18" label="placenta">
+                <assay>ERR315375</assay>
+                <assay technical_replicate_id="t16">ERR315478</assay>
+                <assay technical_replicate_id="t16">ERR315476</assay>
+                <assay technical_replicate_id="t25">ERR315374</assay>
+                <assay technical_replicate_id="t25">ERR315377</assay>
+                <assay technical_replicate_id="t49">ERR315336</assay>
+                <assay technical_replicate_id="t49">ERR315399</assay>
+            </assay_group>
+            <assay_group id="g19" label="prostate gland">
+                <assay>ERR315410</assay>
+                <assay technical_replicate_id="t19">ERR315330</assay>
+                <assay technical_replicate_id="t19">ERR315359</assay>
+                <assay technical_replicate_id="t63">ERR315365</assay>
+                <assay technical_replicate_id="t63">ERR315354</assay>
+                <assay technical_replicate_id="t65">ERR315407</assay>
+                <assay technical_replicate_id="t65">ERR315340</assay>
+            </assay_group>
+            <assay_group id="g20" label="rectum">
+                <assay>ERR579151</assay>
+                <assay>ERR579147</assay>
+                <assay>ERR579127</assay>
+                <assay>ERR579140</assay>
+            </assay_group>
+            <assay_group id="g21" label="saliva-secreting gland">
+                <assay technical_replicate_id="t14">ERR315420</assay>
+                <assay technical_replicate_id="t14">ERR315459</assay>
+                <assay technical_replicate_id="t44">ERR315449</assay>
+                <assay technical_replicate_id="t44">ERR315418</assay>
+                <assay technical_replicate_id="t47">ERR315325</assay>
+                <assay technical_replicate_id="t47">ERR315382</assay>
+            </assay_group>
+            <assay_group id="g22" label="skeletal muscle tissue">
+                <assay>ERR579130</assay>
+                <assay>ERR579141</assay>
+                <assay>ERR579149</assay>
+                <assay>ERR579152</assay>
+                <assay>ERR579143</assay>
+                <assay>ERR579142</assay>
+            </assay_group>
+            <assay_group id="g23" label="small intestine">
+                <assay technical_replicate_id="t29">ERR315344</assay>
+                <assay technical_replicate_id="t29">ERR315419</assay>
+                <assay technical_replicate_id="t34">ERR315364</assay>
+                <assay technical_replicate_id="t34">ERR315408</assay>
+                <assay technical_replicate_id="t58">ERR315409</assay>
+                <assay technical_replicate_id="t58">ERR315423</assay>
+                <assay technical_replicate_id="t9">ERR315388</assay>
+                <assay technical_replicate_id="t9">ERR315381</assay>
+            </assay_group>
+            <assay_group id="g24" label="smooth muscle tissue">
+                <assay>ERR579131</assay>
+                <assay>ERR579153</assay>
+                <assay>ERR579125</assay>
+            </assay_group>
+            <assay_group id="g25" label="spleen">
+                <assay>ERR315473</assay>
+                <assay>ERR315448</assay>
+                <assay>ERR315338</assay>
+                <assay technical_replicate_id="t51">ERR315405</assay>
+                <assay technical_replicate_id="t51">ERR315416</assay>
+            </assay_group>
+            <assay_group id="g26" label="stomach">
+                <assay>ERR315467</assay>
+                <assay>ERR315379</assay>
+                <assay technical_replicate_id="t8">ERR315485</assay>
+                <assay technical_replicate_id="t8">ERR315369</assay>
+            </assay_group>
+            <assay_group id="g27" label="testis">
+                <assay>ERR315492</assay>
+                <assay>ERR315446</assay>
+                <assay>ERR315352</assay>
+                <assay>ERR315456</assay>
+                <assay>ERR315415</assay>
+                <assay>ERR315391</assay>
+                <assay technical_replicate_id="t24">ERR315351</assay>
+                <assay technical_replicate_id="t24">ERR315350</assay>
+            </assay_group>
+            <assay_group id="g28" label="thyroid gland">
+                <assay technical_replicate_id="t28">ERR315397</assay>
+                <assay technical_replicate_id="t28">ERR315483</assay>
+                <assay technical_replicate_id="t28">ERR315491</assay>
+                <assay technical_replicate_id="t50">ERR315358</assay>
+                <assay technical_replicate_id="t50">ERR315422</assay>
+                <assay technical_replicate_id="t55">ERR315337</assay>
+                <assay technical_replicate_id="t55">ERR315412</assay>
+                <assay technical_replicate_id="t62">ERR315363</assay>
+                <assay technical_replicate_id="t62">ERR315428</assay>
+            </assay_group>
+            <assay_group id="g29" label="tonsil">
+                <assay>ERR579135</assay>
+                <assay>ERR579139</assay>
+                <assay>ERR579133</assay>
+            </assay_group>
+            <assay_group id="g30" label="urinary bladder">
+                <assay technical_replicate_id="t21">ERR315453</assay>
+                <assay technical_replicate_id="t21">ERR315447</assay>
+                <assay technical_replicate_id="t21">ERR315334</assay>
+                <assay technical_replicate_id="t36">ERR315355</assay>
+                <assay technical_replicate_id="t36">ERR315421</assay>
+                <assay technical_replicate_id="t36">ERR315370</assay>
+            </assay_group>
+            <assay_group id="g31" label="vermiform appendix">
+                <assay technical_replicate_id="t22">ERR315366</assay>
+                <assay technical_replicate_id="t22">ERR315345</assay>
+                <assay technical_replicate_id="t26">ERR315465</assay>
+                <assay technical_replicate_id="t26">ERR315437</assay>
+                <assay technical_replicate_id="t43">ERR315454</assay>
+                <assay technical_replicate_id="t43">ERR315481</assay>
+            </assay_group>
+            <assay_group id="g32" label="zone of skin">
+                <assay technical_replicate_id="t42">ERR315401</assay>
+                <assay technical_replicate_id="t42">ERR315464</assay>
+                <assay technical_replicate_id="t57">ERR315372</assay>
+                <assay technical_replicate_id="t57">ERR315460</assay>
+                <assay technical_replicate_id="t59">ERR315376</assay>
+                <assay technical_replicate_id="t59">ERR315339</assay>
+            </assay_group>
+        </assay_groups>
+    </analytics>
+</configuration>

--- a/test-data/E-MTAB-3716-configuration.xml
+++ b/test-data/E-MTAB-3716-configuration.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration experimentType="rnaseq_mrna_baseline" r_data="1">
+    <analytics>
+        <assay_groups>
+            <assay_group id="g1" label="cerebellum">
+                <assay>SRR306844</assay>
+                <assay technical_replicate_id="t14">SRR306845</assay>
+            </assay_group>
+            <assay_group id="g2" label="frontal lobe">
+                <assay>SRR306838</assay>
+                <assay>SRR306839</assay>
+            </assay_group>
+            <assay_group id="g3" label="heart">
+                <assay>SRR306847</assay>
+                <assay technical_replicate_id="t15">SRR306849</assay>
+            </assay_group>
+            <assay_group id="g4" label="kidney">
+                <assay>SRR306851</assay>
+                <assay>SRR306853</assay>
+            </assay_group>
+            <assay_group id="g5" label="liver">
+                <assay technical_replicate_id="t16">SRR306854</assay>
+            </assay_group>
+            <assay_group id="g6" label="prefrontal cortex">
+                <assay>SRR306841</assay>
+            </assay_group>
+            <assay_group id="g7" label="temporal lobe">
+                <assay>SRR306843</assay>
+            </assay_group>
+            <assay_group id="g8" label="testis">
+                <assay>SRR306857</assay>
+            </assay_group>
+        </assay_groups>
+    </analytics>
+</configuration>

--- a/test-data/E-MTAB-513-configuration.xml
+++ b/test-data/E-MTAB-513-configuration.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration experimentType="rnaseq_mrna_baseline" r_data="1">
+    <analytics>
+        <assay_groups>
+          <assay_group id="g1" label="leukocyte">
+                <assay>ERR030875</assay>
+          </assay_group>
+          <assay_group id="g2" label="lymph node">
+                <assay>ERR030878</assay>
+          </assay_group>
+          <assay_group id="g3" label="ovary">
+                <assay>ERR030874</assay>
+          </assay_group>
+          <assay_group id="g4" label="breast">
+                <assay>ERR030883</assay>
+          </assay_group>
+          <assay_group id="g5" label="kidney">
+                <assay>ERR030885</assay>
+          </assay_group>
+          <assay_group id="g6" label="liver">
+                <assay>ERR030887</assay>
+          </assay_group>
+          <assay_group id="g7" label="skeletal muscle">
+                <assay>ERR030876</assay>
+          </assay_group>
+          <assay_group id="g8" label="heart">
+                <assay>ERR030886</assay>
+          </assay_group>
+          <assay_group id="g9" label="brain">
+                <assay>ERR030882</assay>
+          </assay_group>
+          <assay_group id="g10" label="prostate">
+                <assay>ERR030877</assay>
+          </assay_group>
+          <assay_group id="g11" label="lung">
+                <assay>ERR030879</assay>
+          </assay_group>
+          <assay_group id="g12" label="thyroid">
+                <assay>ERR030872</assay>
+          </assay_group>
+          <assay_group id="g13" label="colon">
+                <assay>ERR030884</assay>
+          </assay_group>
+          <assay_group id="g14" label="testis">
+                <assay>ERR030873</assay>
+          </assay_group>
+          <assay_group id="g15" label="adipose">
+                <assay>ERR030880</assay>
+          </assay_group>
+          <assay_group id="g16" label="adrenal">
+                <assay>ERR030881</assay>
+          </assay_group>
+        </assay_groups>
+    </analytics>
+</configuration>


### PR DESCRIPTION
While XML configuration files for baseline and differential are more of an Atlas construct, they supplement something that MAGE-Tab doesn't model, but that is relevant in the context of merging for meta-analysis.