### PR TITLE
Subdirectory option

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ optional arguments:
   -h, --help            show this help message and exit
   -x DIRECTORY_WITH_CONFIGURATION_FILES, --directory-with-configuration-files DIRECTORY_WITH_CONFIGURATION_FILES
                         Directory with configuration XMLs to merge
+  -u USE_SUBDIR, --use-subdir USE_SUBDIR
+                        If set to 'True', uses subdirectory structures like created by the retrieve_data.py
+                        function
   --accessions-file ACCESSIONS_FILE
                         File with comma separated list of accessions to use only. Overrides accessions
                         list.
@@ -170,6 +173,9 @@ optional arguments:
   -h, --help            show this help message and exit
   -d INPUT_PATH, --input-path INPUT_PATH
                         Directory with data to merge
+  -u USE_SUBDIR, --use-subdir USE_SUBDIR
+                        If set to 'True', uses subdirectory structures like created by the retrieve_data.py
+                        function
   -o OUTPUT, --output OUTPUT
                         Path for output file.
   -s SUFFIX, --suffix SUFFIX

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ named `<accession>-counts.tsv` where each sample is a column and there is a "Gen
 then executing:
 
 ```
-merge_data.py -d data -s "-counts.tsv" -o merged_result.tsv -c condensed_SDRF.tsv -i "Gene ID" --remove-rows-with-empty
+merge_data.py -d data -s "-counts.tsv" -u True -o merged_result.tsv -c condensed_SDRF.tsv -i "Gene ID" --remove-rows-with-empty
 ```
 
 produces a merged data set with all desired samples. More info:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Once installed, you need to activate that virtual environment before using it ev
 ## Obtain data from Expression Atlas FTP
 
 If all the data that you want to merge is publicly available within Expression Atlas, then you can use this convenience
-call to get all the needed data for a set of Atlas studies:
+call to get all the needed data for a set of Atlas studies. The usual input path is http://ftp.ebi.ac.uk/pub/databases/microarray/data/atlas/experiments/ .
 
 ```
 usage: retrieve_data.py [-h] -i INPUT_PATH -a ACCESSIONS [-d] [-f] [-r]
@@ -127,7 +127,7 @@ Given a set of configuration XML files, named as <ACCESSION>-configuration.xml a
 the following can be run to merge them into a single XML:
 
 ```
-usage: merge_baseline_configuration_xmls.py [-h] -x DIRECTORY_WITH_CONFIGURATION_FILES
+usage: merge_baseline_configuration_xmls.py [-h] -x DIRECTORY_WITH_CONFIGURATION_FILES [-u USE_SUBDIR]
                                             [--accessions-file ACCESSIONS_FILE] [-a ACCESSIONS_LIST] -o
                                             OUTPUT -n NEW_ACCESSION
 
@@ -165,7 +165,7 @@ merge_data.py -d data -s "-counts.tsv" -o merged_result.tsv -c condensed_SDRF.ts
 produces a merged data set with all desired samples. More info:
 
 ```
-usage: merge_data.py [-h] -d INPUT_PATH -o OUTPUT [-s SUFFIX] -c MERGED_CONDENSED -i INDEX_COLUMN [-r REMOVE_ROWS_WITH_EMPTY]
+usage: merge_data.py [-h] -d INPUT_PATH [-u USE_SUBDIR] -o OUTPUT [-s SUFFIX] -c MERGED_CONDENSED -i INDEX_COLUMN [-r REMOVE_ROWS_WITH_EMPTY]
 
 Merges data where samples are in columns, based on samples listed in the condensed SDRF given.
 

--- a/merge_baseline_configuration_xmls.py
+++ b/merge_baseline_configuration_xmls.py
@@ -11,6 +11,11 @@ arg_parser.add_argument('-x', '--directory-with-configuration-files',
                         required=True,
                         help="Directory with configuration XMLs to merge"
                         )
+arg_parser.add_argument('-u', '--use-subdir',
+                        required=False,
+                        help="If set to 'True', uses subdirectory structures like created by the retrieve_data.py function",
+                        default="False"
+                        )   
 arg_parser.add_argument('--accessions-file', required=False,
                         help="File with comma separated list of accessions to use only. "
                              "Overrides accessions list."
@@ -93,7 +98,10 @@ def add_assay_groups_from_accession(path, accession, assay_groups: ET.Element, c
     >>> children[28].get("label") == f"tonsil; {accession}"
     True
     """
-    conf_xml_path = f"{path}/{accession}-configuration.xml"
+    if args.use_subdir == "True":  
+            conf_xml_path = f"{path}/{accession}/{accession}-configuration.xml"
+    else:
+            conf_xml_path = f"{path}/{accession}-configuration.xml"
     ag_counter = 0
     if os.path.isfile(conf_xml_path):
         for ag in get_assay_groups(conf_xml_path):

--- a/merge_data.py
+++ b/merge_data.py
@@ -51,7 +51,10 @@ def merge_data(sample_accession_table, join_type, index_col, input_path, file_su
     """
     merged = None
     for accession in sample_accession_table.Accession.unique().tolist():
-        data = pd.read_csv(f"{input_path}/{accession}{file_suffix}", sep="\t")
+        if args.use_subdir == "True":  
+            data = pd.read_csv(f"{input_path}/{accession}/{accession}{file_suffix}", sep="\t")
+        else:
+            data = pd.read_csv(f"{input_path}/{accession}{file_suffix}", sep="\t")
         cols = [index_col]
         cols.extend(sample_accession_table.loc[sample_accession_table['Accession'] == accession].Sample.unique().tolist())
         # select the samples
@@ -75,8 +78,13 @@ if __name__ == '__main__':
                             required=True,
                             help="Directory with data to merge"
                             )
+    arg_parser.add_argument('-u', '--use-subdir',
+                            required=False,
+                            help="If set to 'True', uses subdirectory structures like created by the retrieve_data.py function",
+                            default="False"
+                            )  
     arg_parser.add_argument('-o', '--output', required=True,
-                            help="Path for output file."
+                            help="Path for output file / filename and format (.tsv)."
                             )
     arg_parser.add_argument('-s', '--suffix', required=False,
                             help="Suffix for counts file after <path>/<accession><suffix>",
@@ -96,12 +104,14 @@ if __name__ == '__main__':
     if args.remove_rows_with_empty:
         merge_type = "inner"  # inner join: only what is shared by the two pds being merged
 
+    print("merging the files")
     result = merge_data(sample_accession_table=sample_accession,
                         join_type=merge_type,
                         index_col=args.index_column,
                         input_path=args.input_path,
                         file_suffix=args.suffix)
 
+    print("exporting the results")
     result.to_csv(args.output, sep="\t", index=False)
 
 


### PR DESCRIPTION
Dear Sirs or Madams,

While working with the MAGE-Tab merger package, I have noticed that the retrieve_data.py function creates a subdirectory for each experiment into which it puts the data. The functions merge_data.py and the function merge_baseline_configuration_xmls.py are not able to look into those subdirectories. Instead, both functions expect to find every file inside one single folder. This is a little inconvenient. Therefore, I added the option to look into subfolders to both these functions and adjusted the README file as well.
I hope you find these changes helpful.

Sincerely,
Lucas Barck